### PR TITLE
feat: add react wrapper with gradient and image customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,44 @@ If you install through `npm`, precompiled files will be available in `node_modul
 
 The precompiled bundle have support for [Internet Explorer 10+, Safari 5.1+, and all evergreen browsers](https://browserl.ist/?q=defaults%2C+IE+%3E%3D+10%2C+Safari+%3E%3D+5.1).
 
+### React component
+
+This library includes a tiny React wrapper located at `qrcode/lib/react`.
+It renders the QR code inside a `<canvas>` element and forwards all
+options supported by the core renderer.
+
+```jsx
+import QRCode from 'qrcode/lib/react'
+
+export default function Example () {
+  return (
+    <QRCode
+      value='Hello world'
+      options={{
+        gradient: {
+          type: 'linear',
+          rotation: 45,
+          colorStops: [
+            { offset: 0, color: '#ff0080' },
+            { offset: 1, color: '#00f0ff' }
+          ]
+        },
+        image: document.getElementById('logo')
+      }}
+    />
+  )
+}
+```
+
+#### Gradient and center image
+
+The canvas renderer now accepts a `gradient` option to draw modules with a
+linear or radial gradient and an `image` option to place a custom image in
+the middle of the code. The `image` option should be any `CanvasImageSource`
+such as an `HTMLImageElement`, while `gradient` specifies the gradient
+type, rotation and color stops. Optional `imageSize`, `imageWidth` and
+`imageHeight` may be provided to control the overlay dimensions.
+
 ### NodeJS
 Require the module `qrcode`
 

--- a/lib/react.js
+++ b/lib/react.js
@@ -1,0 +1,16 @@
+import React, { useEffect, useRef } from 'react'
+import { toCanvas } from './index.js'
+
+export function QRCode ({ value, options = {}, ...props }) {
+  const canvasRef = useRef(null)
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      toCanvas(canvasRef.current, value, options)
+    }
+  }, [value, options])
+
+  return React.createElement('canvas', { ref: canvasRef, ...props })
+}
+
+export default QRCode

--- a/lib/renderer/canvas.js
+++ b/lib/renderer/canvas.js
@@ -18,6 +18,34 @@ function getCanvasElement () {
   }
 }
 
+function rgbaStr (rgba) {
+  const alpha = rgba.a / 255
+  return 'rgba(' + rgba.r + ',' + rgba.g + ',' + rgba.b + ',' + alpha + ')'
+}
+
+function createGradient (ctx, size, opts) {
+  const type = opts.type || 'linear'
+  const colorStops = opts.colorStops || []
+  let gradient
+  if (type === 'radial') {
+    const r = size / 2
+    gradient = ctx.createRadialGradient(r, r, 0, r, r, r)
+  } else {
+    const angle = (opts.rotation || 0) * Math.PI / 180
+    const x0 = size / 2 + Math.cos(angle + Math.PI) * size / 2
+    const y0 = size / 2 + Math.sin(angle + Math.PI) * size / 2
+    const x1 = size / 2 + Math.cos(angle) * size / 2
+    const y1 = size / 2 + Math.sin(angle) * size / 2
+    gradient = ctx.createLinearGradient(x0, y0, x1, y1)
+  }
+
+  colorStops.forEach(function (c) {
+    gradient.addColorStop(c.offset, c.color)
+  })
+
+  return gradient
+}
+
 export function render (qrData, canvas, options) {
   let opts = options
   let canvasEl = canvas
@@ -32,14 +60,45 @@ export function render (qrData, canvas, options) {
   }
 
   opts = Utils.getOptions(opts)
-  const size = Utils.getImageWidth(qrData.modules.size, opts)
+  const qrSize = qrData.modules.size
+  const size = Utils.getImageWidth(qrSize, opts)
+  const scale = Utils.getScale(qrSize, opts)
 
   const ctx = canvasEl.getContext('2d')
-  const image = ctx.createImageData(size, size)
-  Utils.qrToImageData(image.data, qrData, opts)
-
   clearCanvas(ctx, canvasEl, size)
-  ctx.putImageData(image, 0, 0)
+
+  if (opts.gradient) {
+    const data = qrData.modules.data
+    ctx.fillStyle = rgbaStr(opts.color.light)
+    ctx.fillRect(0, 0, size, size)
+
+    const grad = createGradient(ctx, size, opts.gradient)
+    ctx.fillStyle = grad
+    for (let r = 0; r < qrSize; r++) {
+      for (let c = 0; c < qrSize; c++) {
+        if (data[r * qrSize + c]) {
+          ctx.fillRect((opts.margin + c) * scale, (opts.margin + r) * scale, scale, scale)
+        }
+      }
+    }
+  } else {
+    const image = ctx.createImageData(size, size)
+    Utils.qrToImageData(image.data, qrData, opts)
+    ctx.putImageData(image, 0, 0)
+  }
+
+  if (opts.image) {
+    const img = opts.image
+    const w = opts.imageWidth || opts.imageSize || img.width || size * 0.2
+    const h = opts.imageHeight || opts.imageSize || img.height || size * 0.2
+    const dx = (size - w) / 2
+    const dy = (size - h) / 2
+    try {
+      ctx.drawImage(img, dx, dy, w, h)
+    } catch (e) {
+      // ignore errors if image cannot be drawn
+    }
+  }
 
   return canvasEl
 }

--- a/lib/renderer/utils.js
+++ b/lib/renderer/utils.js
@@ -54,6 +54,14 @@ export function getOptions (options) {
       dark: hex2rgba(options.color.dark || '#000000ff'),
       light: hex2rgba(options.color.light || '#ffffffff')
     },
+    // gradient configuration used by canvas renderer when provided.
+    // example: { type: 'linear', rotation: 0, colorStops: [{ offset: 0, color: '#f00' }, { offset: 1, color: '#00f' }] }
+    gradient: options.gradient,
+    // optional CanvasImageSource to be drawn at the center of the code
+    image: options.image,
+    imageSize: options.imageSize,
+    imageWidth: options.imageWidth,
+    imageHeight: options.imageHeight,
     type: options.type,
     rendererOpts: options.rendererOpts || {}
   }


### PR DESCRIPTION
## Summary
- support gradient fills and center images in canvas renderer
- expose basic React component
- document new options and React usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aad5204848832883eb7c46e5c1bd2c